### PR TITLE
Export error sentinels as public

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -13,11 +13,11 @@ const (
 )
 
 var (
-	errCorruptHeader     = errors.New("rardecode: corrupt block header")
-	errCorruptFileHeader = errors.New("rardecode: corrupt file header")
-	errBadHeaderCrc      = errors.New("rardecode: bad header crc")
-	errUnknownDecoder    = errors.New("rardecode: unknown decoder version")
-	errDecoderOutOfData  = errors.New("rardecode: decoder expected more data than is in packed file")
+	ErrCorruptHeader     = errors.New("rardecode: corrupt block header")
+	ErrCorruptFileHeader = errors.New("rardecode: corrupt file header")
+	ErrBadHeaderCrc      = errors.New("rardecode: bad header crc")
+	ErrUnknownDecoder    = errors.New("rardecode: unknown decoder version")
+	ErrDecoderOutOfData  = errors.New("rardecode: decoder expected more data than is in packed file")
 )
 
 type readBuf []byte
@@ -111,6 +111,6 @@ func newFileBlockReader(v *volume) (fileBlockReader, error) {
 	case 1:
 		return newArchive50(pass), nil
 	default:
-		return nil, errUnknownArc
+		return nil, ErrUnknownArc
 	}
 }

--- a/archive15.go
+++ b/archive15.go
@@ -50,7 +50,7 @@ const (
 )
 
 var (
-	errUnsupportedDecoder = errors.New("rardecode: unsupported decoder version")
+	ErrUnsupportedDecoder = errors.New("rardecode: unsupported decoder version")
 )
 
 type blockHeader15 struct {
@@ -255,7 +255,7 @@ func (a *archive15) parseFileHeader(h *blockHeader15) (*fileBlockHeader, error) 
 
 	b := h.data
 	if len(b) < 21 {
-		return nil, errCorruptFileHeader
+		return nil, ErrCorruptFileHeader
 	}
 
 	f.PackedSize = h.dataSize
@@ -273,7 +273,7 @@ func (a *archive15) parseFileHeader(h *blockHeader15) (*fileBlockHeader, error) 
 	f.Attributes = int64(b.uint32())
 	if h.flags&fileLargeData > 0 {
 		if len(b) < 8 {
-			return nil, errCorruptFileHeader
+			return nil, ErrCorruptFileHeader
 		}
 		_ = b.uint32() // already read large PackedSize in readBlockHeader
 		f.UnPackedSize |= int64(b.uint32()) << 32
@@ -283,7 +283,7 @@ func (a *archive15) parseFileHeader(h *blockHeader15) (*fileBlockHeader, error) 
 		f.UnPackedSize = -1
 	}
 	if len(b) < namesize {
-		return nil, errCorruptFileHeader
+		return nil, ErrCorruptFileHeader
 	}
 	name := b.bytes(namesize)
 	if h.flags&fileUnicode == 0 {
@@ -309,7 +309,7 @@ func (a *archive15) parseFileHeader(h *blockHeader15) (*fileBlockHeader, error) 
 	var salt []byte
 	if h.flags&fileSalt > 0 {
 		if len(b) < saltSize {
-			return nil, errCorruptFileHeader
+			return nil, ErrCorruptFileHeader
 		}
 		salt = b.bytes(saltSize)
 	}
@@ -328,13 +328,13 @@ func (a *archive15) parseFileHeader(h *blockHeader15) (*fileBlockHeader, error) 
 	if method != 0 {
 		switch unpackver {
 		case 15:
-			return nil, errUnsupportedDecoder
+			return nil, ErrUnsupportedDecoder
 		case 20, 26:
 			f.decVer = decode20Ver
 		case 29:
 			f.decVer = decode29Ver
 		default:
-			return nil, errUnknownDecoder
+			return nil, ErrUnknownDecoder
 		}
 	}
 	return f, nil
@@ -367,7 +367,7 @@ func (a *archive15) readBlockHeader(r sliceReader) (*blockHeader15, error) {
 	h.flags = b.uint16()
 	size := int(b.uint16())
 	if size < 7 {
-		return nil, errCorruptHeader
+		return nil, ErrCorruptHeader
 	}
 	h.data, err = r.readSlice(size)
 	if err != nil {
@@ -379,18 +379,18 @@ func (a *archive15) readBlockHeader(r sliceReader) (*blockHeader15, error) {
 	hash := crc32.NewIEEE()
 	_, _ = hash.Write(h.data[2:]) // Write should always succeed
 	if crc != uint16(hash.Sum32()) {
-		return nil, errBadHeaderCrc
+		return nil, ErrBadHeaderCrc
 	}
 	h.data = h.data[7:]
 	if h.flags&blockHasData > 0 {
 		if len(h.data) < 4 {
-			return nil, errCorruptHeader
+			return nil, ErrCorruptHeader
 		}
 		h.dataSize = int64(h.data.uint32())
 	}
 	if (h.htype == blockService || h.htype == blockFile) && h.flags&fileLargeData > 0 {
 		if len(h.data) < 25 {
-			return nil, errCorruptHeader
+			return nil, ErrCorruptHeader
 		}
 		b := h.data[21:25]
 		h.dataSize |= int64(b.uint32()) << 32

--- a/archive50.go
+++ b/archive50.go
@@ -52,9 +52,9 @@ const (
 )
 
 var (
-	errBadPassword      = errors.New("rardecode: incorrect password")
-	errCorruptEncrypt   = errors.New("rardecode: corrupt encryption data")
-	errUnknownEncMethod = errors.New("rardecode: unknown encryption method")
+	ErrBadPassword      = errors.New("rardecode: incorrect password")
+	ErrCorruptEncrypt   = errors.New("rardecode: corrupt encryption data")
+	ErrUnknownEncMethod = errors.New("rardecode: unknown encryption method")
 )
 
 type extra struct {
@@ -159,7 +159,7 @@ func (a *archive50) getKeys(kdfCount int, salt, check []byte) ([][]byte, error) 
 	var keys [][]byte
 
 	if kdfCount > maxKdfCount {
-		return nil, errCorruptEncrypt
+		return nil, ErrCorruptEncrypt
 	}
 	kdfCount = 1 << uint(kdfCount)
 
@@ -183,7 +183,7 @@ func (a *archive50) getKeys(kdfCount int, salt, check []byte) ([][]byte, error) 
 
 	// check password
 	if check != nil && !bytes.Equal(check, keys[2]) {
-		return nil, errBadPassword
+		return nil, ErrBadPassword
 	}
 	return keys, nil
 }
@@ -191,11 +191,11 @@ func (a *archive50) getKeys(kdfCount int, salt, check []byte) ([][]byte, error) 
 // parseFileEncryptionRecord processes the optional file encryption record from a file header.
 func (a *archive50) parseFileEncryptionRecord(b readBuf, f *fileBlockHeader) error {
 	if ver := b.uvarint(); ver != 0 {
-		return errUnknownEncMethod
+		return ErrUnknownEncMethod
 	}
 	flags := b.uvarint()
 	if len(b) < 33 {
-		return errCorruptEncrypt
+		return ErrCorruptEncrypt
 	}
 	kdfCount := int(b.byte())
 	salt := b.bytes(16)
@@ -204,7 +204,7 @@ func (a *archive50) parseFileEncryptionRecord(b readBuf, f *fileBlockHeader) err
 	var check []byte
 	if flags&file5EncCheckPresent > 0 {
 		if len(b) < 12 {
-			return errCorruptEncrypt
+			return ErrCorruptEncrypt
 		}
 		check = b.bytes(12)
 	}
@@ -235,13 +235,13 @@ func (a *archive50) parseFileHeader(h *blockHeader50) (*fileBlockHeader, error) 
 	f.Attributes = int64(h.data.uvarint())
 	if flags&file5HasUnixMtime > 0 {
 		if len(h.data) < 4 {
-			return nil, errCorruptFileHeader
+			return nil, ErrCorruptFileHeader
 		}
 		f.ModificationTime = time.Unix(int64(h.data.uint32()), 0)
 	}
 	if flags&file5HasCRC32 > 0 {
 		if len(h.data) < 4 {
-			return nil, errCorruptFileHeader
+			return nil, ErrCorruptFileHeader
 		}
 		f.sum = append([]byte(nil), h.data.bytes(4)...)
 		if f.first {
@@ -257,7 +257,7 @@ func (a *archive50) parseFileHeader(h *blockHeader50) (*fileBlockHeader, error) 
 	if f.first && method != 0 {
 		unpackver := flags & 0x003f
 		if unpackver != 0 {
-			return nil, errUnknownDecoder
+			return nil, ErrUnknownDecoder
 		}
 		f.decVer = decode50Ver
 	}
@@ -271,7 +271,7 @@ func (a *archive50) parseFileHeader(h *blockHeader50) (*fileBlockHeader, error) 
 	}
 	nlen := int(h.data.uvarint())
 	if len(h.data) < nlen {
-		return nil, errCorruptFileHeader
+		return nil, ErrCorruptFileHeader
 	}
 	f.Name = string(h.data.bytes(nlen))
 
@@ -303,11 +303,11 @@ func (a *archive50) parseFileHeader(h *blockHeader50) (*fileBlockHeader, error) 
 // parseEncryptionBlock calculates the key for block encryption.
 func (a *archive50) parseEncryptionBlock(b readBuf) error {
 	if ver := b.uvarint(); ver != 0 {
-		return errUnknownEncMethod
+		return ErrUnknownEncMethod
 	}
 	flags := b.uvarint()
 	if len(b) < 17 {
-		return errCorruptEncrypt
+		return ErrCorruptEncrypt
 	}
 	kdfCount := int(b.byte())
 	salt := b.bytes(16)
@@ -315,7 +315,7 @@ func (a *archive50) parseEncryptionBlock(b readBuf) error {
 	var check []byte
 	if flags&enc5CheckPresent > 0 {
 		if len(b) < 12 {
-			return errCorruptEncrypt
+			return ErrCorruptEncrypt
 		}
 		check = b.bytes(12)
 	}
@@ -357,7 +357,7 @@ func (a *archive50) readBlockHeader(r sliceReader) (*blockHeader50, error) {
 	// check header crc
 	_, _ = hash.Write(b[4:])
 	if crc != hash.Sum32() {
-		return nil, errBadHeaderCrc
+		return nil, ErrBadHeaderCrc
 	}
 
 	b = b[len(b)-size:]
@@ -373,7 +373,7 @@ func (a *archive50) readBlockHeader(r sliceReader) (*blockHeader50, error) {
 		h.dataSize = int64(b.uvarint())
 	}
 	if len(b) < extraSize {
-		return nil, errCorruptHeader
+		return nil, ErrCorruptHeader
 	}
 	h.data = b.bytes(len(b) - extraSize)
 
@@ -381,7 +381,7 @@ func (a *archive50) readBlockHeader(r sliceReader) (*blockHeader50, error) {
 	for len(b) > 0 {
 		size = int(b.uvarint())
 		if len(b) < size {
-			return nil, errCorruptHeader
+			return nil, ErrCorruptHeader
 		}
 		data := readBuf(b.bytes(size))
 		ftype := data.uvarint()

--- a/bit_reader.go
+++ b/bit_reader.go
@@ -32,7 +32,7 @@ func (r *rar5BitReader) ReadByte() (byte, error) {
 		r.b, err = r.r.bytes()
 		if err != nil {
 			if err == io.EOF {
-				err = errDecoderOutOfData
+				err = ErrDecoderOutOfData
 			}
 			return 0, err
 		}
@@ -67,7 +67,7 @@ func (r *rar5BitReader) readBits(n uint8) (int, error) {
 			if err != nil {
 				if err == io.EOF {
 					// io.EOF before we reached bit limit
-					err = errDecoderOutOfData
+					err = ErrDecoderOutOfData
 				}
 				return 0, err
 			}

--- a/decode20.go
+++ b/decode20.go
@@ -65,7 +65,7 @@ func readCodeLengthTable20(br *rarBitReader, table []byte) error {
 		}
 		if l == 16 {
 			if i == 0 {
-				return errInvalidLengthTable
+				return ErrInvalidLengthTable
 			}
 			var n int
 			n, err = br.readBits(2)
@@ -152,11 +152,11 @@ func (d *decoder20) fill(dr *decodeReader) error {
 		switch err {
 		case nil:
 			continue
-		case errEndOfBlock:
+		case ErrEndOfBlock:
 			d.hdrRead = false
 			continue
 		case io.EOF:
-			err = errDecoderOutOfData
+			err = ErrDecoderOutOfData
 		}
 		return err
 	}

--- a/decode20_audio.go
+++ b/decode20_audio.go
@@ -115,7 +115,7 @@ func (d *audio20Decoder) fill(dr *decodeReader, size int64) (int64, error) {
 			return n, err
 		}
 		if sym == 256 {
-			return n, errEndOfBlock
+			return n, ErrEndOfBlock
 		}
 		dr.writeByte(d.decode(sym))
 		n++

--- a/decode20_lz.go
+++ b/decode20_lz.go
@@ -132,7 +132,7 @@ func (d *lz20Decoder) fill(dr *decodeReader, size int64) (int64, error) {
 		case sym > 269:
 			err = d.decodeOffset(dr, sym-270)
 		case sym == 269:
-			return n, errEndOfBlock
+			return n, ErrEndOfBlock
 		case sym == 256: // use previous offset and length
 			copy(d.offset[1:], d.offset[:])
 		case sym < 261:

--- a/decode29.go
+++ b/decode29.go
@@ -12,9 +12,9 @@ const (
 
 var (
 	// Errors marking the end of the decoding block and/or file
-	errEndOfFile         = errors.New("rardecode: end of file")
-	errEndOfBlock        = errors.New("rardecode: end of block")
-	errEndOfBlockAndFile = errors.New("rardecode: end of block and file")
+	ErrEndOfFile         = errors.New("rardecode: end of file")
+	ErrEndOfBlock        = errors.New("rardecode: end of block")
+	ErrEndOfBlockAndFile = errors.New("rardecode: end of block and file")
 )
 
 // decoder29 implements the decoder interface for RAR 3.0 compression (unpack version 29)
@@ -70,7 +70,7 @@ func readVMCode(br *rarBitReader) ([]byte, error) {
 		return nil, err
 	}
 	if n > maxCodeSize || n == 0 {
-		return nil, errInvalidFilter
+		return nil, ErrInvalidFilter
 	}
 	buf := make([]byte, n)
 	err = br.readFull(buf)
@@ -83,7 +83,7 @@ func readVMCode(br *rarBitReader) ([]byte, error) {
 	}
 	// simple xor checksum on data
 	if x != buf[0] {
-		return nil, errInvalidFilter
+		return nil, ErrInvalidFilter
 	}
 	return buf, nil
 }
@@ -105,10 +105,10 @@ func (d *decoder29) parseVMFilter(buf []byte) (*filterBlock, error) {
 		} else {
 			n--
 			if n > maxUniqueFilters {
-				return nil, errInvalidFilter
+				return nil, ErrInvalidFilter
 			}
 			if int(n) > len(d.filters) {
-				return nil, errInvalidFilter
+				return nil, ErrInvalidFilter
 			}
 		}
 		d.fnum = int(n)
@@ -178,7 +178,7 @@ func (d *decoder29) parseVMFilter(buf []byte) (*filterBlock, error) {
 			return nil, err
 		}
 		if n > vmGlobalSize-vmFixedGlobalSize {
-			return nil, errInvalidFilter
+			return nil, ErrInvalidFilter
 		}
 		g = make([]byte, n)
 		err = br.readFull(g)
@@ -216,7 +216,7 @@ func (d *decoder29) readBlockHeader() error {
 		}
 	}
 	if err == io.EOF {
-		err = errDecoderOutOfData
+		err = ErrDecoderOutOfData
 	}
 	d.hdrRead = true
 	return err
@@ -252,18 +252,18 @@ func (d *decoder29) fill(dr *decodeReader) error {
 		switch err {
 		case nil:
 			continue
-		case errEndOfBlock:
+		case ErrEndOfBlock:
 			d.hdrRead = false
 			continue
-		case errEndOfFile:
+		case ErrEndOfFile:
 			d.eof = true
 			err = io.EOF
-		case errEndOfBlockAndFile:
+		case ErrEndOfBlockAndFile:
 			d.eof = true
 			d.hdrRead = false
 			err = io.EOF
 		case io.EOF:
-			err = errDecoderOutOfData
+			err = ErrDecoderOutOfData
 		}
 		return err
 	}

--- a/decode29_lz.go
+++ b/decode29_lz.go
@@ -117,16 +117,16 @@ func (d *lz29Decoder) readEndOfBlock() error {
 		return err
 	}
 	if n > 0 {
-		return errEndOfBlock
+		return ErrEndOfBlock
 	}
 	n, err = d.br.readBits(1)
 	if err != nil {
 		return err
 	}
 	if n > 0 {
-		return errEndOfBlockAndFile
+		return ErrEndOfBlockAndFile
 	}
-	return errEndOfFile
+	return ErrEndOfFile
 }
 
 func (d *lz29Decoder) decodeLength(dr *decodeReader, i int) error {

--- a/decode29_ppm.go
+++ b/decode29_ppm.go
@@ -105,9 +105,9 @@ func (d *ppm29Decoder) fill(dr *decodeReader) ([]byte, error) {
 
 		switch c {
 		case 0:
-			return nil, errEndOfBlock
+			return nil, ErrEndOfBlock
 		case 2:
-			return nil, errEndOfBlockAndFile
+			return nil, ErrEndOfBlockAndFile
 		case 3:
 			return d.readFilterData()
 		case 4:

--- a/decode50.go
+++ b/decode50.go
@@ -14,8 +14,8 @@ const (
 )
 
 var (
-	errUnknownFilter       = errors.New("rardecode: unknown V5 filter")
-	errCorruptDecodeHeader = errors.New("rardecode: corrupt decode header")
+	ErrUnknownFilter       = errors.New("rardecode: unknown V5 filter")
+	ErrCorruptDecodeHeader = errors.New("rardecode: corrupt decode header")
 )
 
 // decoder50 implements the decoder interface for RAR 5 compression.
@@ -62,7 +62,7 @@ func (d *decoder50) readBlockHeader() error {
 
 	bytecount := (flags>>3)&3 + 1
 	if bytecount == 4 {
-		return errCorruptDecodeHeader
+		return ErrCorruptDecodeHeader
 	}
 
 	hsum, err := d.br.ReadByte()
@@ -83,7 +83,7 @@ func (d *decoder50) readBlockHeader() error {
 		blockBytes |= int(n) << (i * 8)
 	}
 	if sum != hsum { // bad header checksum
-		return errCorruptDecodeHeader
+		return ErrCorruptDecodeHeader
 	}
 	blockBits += (blockBytes - 1) * 8
 
@@ -176,7 +176,7 @@ func (d *decoder50) readFilter(dr *decodeReader) error {
 	case 3:
 		fb.filter = filterArm
 	default:
-		return errUnknownFilter
+		return ErrUnknownFilter
 	}
 	return dr.queueFilter(fb)
 }
@@ -293,7 +293,7 @@ func (d *decoder50) fill(dr *decodeReader) error {
 		}
 		if err != nil {
 			if err == io.EOF {
-				return errDecoderOutOfData
+				return ErrDecoderOutOfData
 			}
 			return err
 		}

--- a/decode_reader.go
+++ b/decode_reader.go
@@ -8,9 +8,9 @@ const (
 )
 
 var (
-	errTooManyFilters   = errors.New("rardecode: too many filters")
-	errInvalidFilter    = errors.New("rardecode: invalid filter")
-	errMultipleDecoders = errors.New("rardecode: multiple decoders in a single archive not supported")
+	ErrTooManyFilters   = errors.New("rardecode: too many filters")
+	ErrInvalidFilter    = errors.New("rardecode: invalid filter")
+	ErrMultipleDecoders = errors.New("rardecode: multiple decoders in a single archive not supported")
 )
 
 // filter functions take a byte slice, the current output offset and
@@ -94,10 +94,10 @@ func (d *decodeReader) init(r byteReader, ver int, winsize uint, reset bool, unP
 		case decode20Ver:
 			d.dec = new(decoder20)
 		default:
-			return errUnknownDecoder
+			return ErrUnknownDecoder
 		}
 	} else if d.dec.version() != ver {
-		return errMultipleDecoders
+		return ErrMultipleDecoders
 	}
 	d.dec.init(r, reset, unPackedSize)
 	return nil
@@ -150,7 +150,7 @@ func (d *decodeReader) copyBytes(length, offset int) {
 // queueFilter adds a filterBlock to the end decodeReader's filters.
 func (d *decodeReader) queueFilter(f *filterBlock) error {
 	if len(d.fl) >= maxQueuedFilters {
-		return errTooManyFilters
+		return ErrTooManyFilters
 	}
 	// make offset relative to read index (from write index)
 	f.offset += d.w - d.r
@@ -158,7 +158,7 @@ func (d *decodeReader) queueFilter(f *filterBlock) error {
 	for _, fb := range d.fl {
 		if f.offset < fb.offset {
 			// filter block must not start before previous filter
-			return errInvalidFilter
+			return ErrInvalidFilter
 		}
 		f.offset -= fb.offset
 	}
@@ -243,7 +243,7 @@ func (d *decodeReader) processFilters() ([]byte, error) {
 			return b, nil
 		}
 		if f.length != len(b) {
-			return nil, errInvalidFilter
+			return nil, ErrInvalidFilter
 		}
 	}
 }
@@ -269,7 +269,7 @@ func (d *decodeReader) bytes() ([]byte, error) {
 	// check filters
 	f := d.fl[0]
 	if f.offset < 0 {
-		return nil, errInvalidFilter
+		return nil, ErrInvalidFilter
 	}
 	if f.offset > 0 {
 		// filter not at current read index, output bytes before it

--- a/filters.go
+++ b/filters.go
@@ -296,7 +296,7 @@ type vmFilter struct {
 // execute implements v3filter type for VM based RAR 3 filters.
 func (f *vmFilter) execute(r map[int]uint32, global, buf []byte, offset int64) ([]byte, error) {
 	if len(buf) > vmGlobalAddr {
-		return buf, errInvalidFilter
+		return buf, ErrInvalidFilter
 	}
 	v := newVM(buf)
 

--- a/huffman.go
+++ b/huffman.go
@@ -12,8 +12,8 @@ const (
 )
 
 var (
-	errHuffDecodeFailed   = errors.New("rardecode: huffman decode failed")
-	errInvalidLengthTable = errors.New("rardecode: invalid huffman code length table")
+	ErrHuffDecodeFailed   = errors.New("rardecode: huffman decode failed")
+	ErrInvalidLengthTable = errors.New("rardecode: invalid huffman code length table")
 )
 
 type huffmanDecoder struct {
@@ -131,7 +131,7 @@ func (h *huffmanDecoder) readSym(r bitReader) (int, error) {
 
 	pos := int(h.pos[bits]) + int(dist)
 	if pos >= len(h.symbol) {
-		return 0, errHuffDecodeFailed
+		return 0, ErrHuffDecodeFailed
 	}
 
 	return int(h.symbol[pos]), nil
@@ -194,7 +194,7 @@ func readCodeLengthTable(br bitReader, codeLength []byte, addOld bool) error {
 		}
 		if l < 18 {
 			if i == 0 {
-				return errInvalidLengthTable
+				return ErrInvalidLengthTable
 			}
 			value = codeLength[i-1]
 		}

--- a/ppm_model.go
+++ b/ppm_model.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	errCorruptPPM = errors.New("rardecode: corrupt ppm data")
+	ErrCorruptPPM = errors.New("rardecode: corrupt ppm data")
 
 	expEscape  = []byte{25, 14, 9, 7, 5, 5, 4, 4, 4, 3, 3, 3, 2, 2, 2, 2}
 	initBinEsc = []uint16{0x3CDD, 0x1F3F, 0x59BF, 0x48F3, 0x64A1, 0x5ABC, 0x6632, 0x6051}
@@ -616,7 +616,7 @@ func (m *model) init(br io.ByteReader, reset bool, maxOrder, maxMB int) error {
 	m.a.init(maxMB)
 
 	if maxOrder == 1 {
-		return errCorruptPPM
+		return ErrCorruptPPM
 	}
 	m.maxOrder = maxOrder
 	m.prevSym = 0
@@ -718,7 +718,7 @@ func (m *model) decodeSymbol1(c context) (*state, error) {
 	// protect against divide by zero
 	// TODO: look at why this happens, may be problem elsewhere
 	if scale == 0 {
-		return nil, errCorruptPPM
+		return nil, ErrCorruptPPM
 	}
 	count := m.rc.currentCount(scale)
 	m.prevSuccess = 0
@@ -799,7 +799,7 @@ func (m *model) decodeSymbol2(c context, numMasked int) (*state, error) {
 	count := m.rc.currentCount(scale)
 
 	if count >= scale {
-		return nil, errCorruptPPM
+		return nil, ErrCorruptPPM
 	}
 	if count >= hi {
 		err := m.rc.decode(hi, scale)
@@ -1044,7 +1044,7 @@ func (m *model) ReadByte() (byte, error) {
 			m.orderFall++
 			minC = m.a.contextSuffix(minC)
 			if minC <= 0 {
-				return 0, errCorruptPPM
+				return 0, ErrCorruptPPM
 			}
 		}
 		s, err = m.decodeSymbol2(minC, n)

--- a/reader.go
+++ b/reader.go
@@ -28,12 +28,12 @@ const (
 )
 
 var (
-	errShortFile        = errors.New("rardecode: decoded file too short")
-	errInvalidFileBlock = errors.New("rardecode: invalid file block")
-	errUnexpectedArcEnd = errors.New("rardecode: unexpected end of archive")
-	errBadFileChecksum  = errors.New("rardecode: bad file checksum")
-	errSolidOpen        = errors.New("rardecode: solid files don't support Open")
-	errUnknownArc       = errors.New("rardecode: unknown archive version")
+	ErrShortFile        = errors.New("rardecode: decoded file too short")
+	ErrInvalidFileBlock = errors.New("rardecode: invalid file block")
+	ErrUnexpectedArcEnd = errors.New("rardecode: unexpected end of archive")
+	ErrBadFileChecksum  = errors.New("rardecode: bad file checksum")
+	ErrSolidOpen        = errors.New("rardecode: solid files don't support Open")
+	ErrUnknownArc       = errors.New("rardecode: unknown archive version")
 )
 
 // FileHeader represents a single file in a RAR archive.
@@ -140,12 +140,12 @@ func (f *packedFileReader) nextBlock() error {
 	if err != nil {
 		if err == io.EOF {
 			// archive ended, but file hasn't
-			return errUnexpectedArcEnd
+			return ErrUnexpectedArcEnd
 		}
 		return err
 	}
 	if h.first || h.Name != f.h.Name {
-		return errInvalidFileBlock
+		return ErrInvalidFileBlock
 	}
 	f.n = h.PackedSize
 	f.h = h
@@ -167,7 +167,7 @@ func (f *packedFileReader) next() (*fileBlockHeader, error) {
 		return nil, err
 	}
 	if !f.h.first {
-		return nil, errInvalidFileBlock
+		return nil, ErrInvalidFileBlock
 	}
 	f.n = f.h.PackedSize
 	return f.h, nil
@@ -297,7 +297,7 @@ func (cr *checksumReader) eofError() error {
 		}
 	}
 	if !bytes.Equal(sum, h.sum) {
-		return errBadFileChecksum
+		return ErrBadFileChecksum
 	}
 	return io.EOF
 }
@@ -421,7 +421,7 @@ func (r *Reader) nextFile() error {
 	}
 	if h.UnPackedSize >= 0 && !h.UnKnownSize {
 		// Limit reading to UnPackedSize as there may be padding
-		r.r = &limitedReader{r.r, h.UnPackedSize, errShortFile}
+		r.r = &limitedReader{r.r, h.UnPackedSize, ErrShortFile}
 	}
 	if h.hash != nil {
 		r.r = &checksumReader{r.r, h.hash(), r.pr}
@@ -471,7 +471,7 @@ type File struct {
 // contents instead.
 func (f *File) Open() (io.ReadCloser, error) {
 	if f.Solid {
-		return nil, errSolidOpen
+		return nil, ErrSolidOpen
 	}
 	r := new(ReadCloser)
 	r.pr = f.pr.clone()

--- a/vm.go
+++ b/vm.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	errInvalidVMInstruction = errors.New("rardecode: invalid vm instruction")
+	ErrInvalidVMInstruction = errors.New("rardecode: invalid vm instruction")
 )
 
 type vm struct {
@@ -655,7 +655,7 @@ func readCommands(br *rarBitReader) ([]command, error) {
 		}
 
 		if code >= len(ops) {
-			return cmds, errInvalidVMInstruction
+			return cmds, ErrInvalidVMInstruction
 		}
 		ins := ops[code]
 

--- a/volume.go
+++ b/volume.go
@@ -21,10 +21,10 @@ const (
 )
 
 var (
-	errNoSig            = errors.New("rardecode: RAR signature not found")
-	errVerMismatch      = errors.New("rardecode: volume version mistmatch")
-	errArchiveNameEmpty = errors.New("rardecode: archive name empty")
-	errFileNameRequired = errors.New("rardecode: filename required for multi volume archive")
+	ErrNoSig            = errors.New("rardecode: RAR signature not found")
+	ErrVerMismatch      = errors.New("rardecode: volume version mistmatch")
+	ErrArchiveNameEmpty = errors.New("rardecode: archive name empty")
+	ErrFileNameRequired = errors.New("rardecode: filename required for multi volume archive")
 )
 
 type option struct {
@@ -88,7 +88,7 @@ func (v *volume) openFile(file string) error {
 	var f io.Reader
 
 	if len(file) == 0 {
-		return errArchiveNameEmpty
+		return ErrArchiveNameEmpty
 	}
 	if fs := v.opt.fs; fs != nil {
 		f, err = fs.Open(v.dir + file)
@@ -209,7 +209,7 @@ func (v *volume) findSig() error {
 			continue
 		} else if err != nil {
 			if err == io.EOF {
-				err = errNoSig
+				err = ErrNoSig
 			}
 			return err
 		}
@@ -217,7 +217,7 @@ func (v *volume) findSig() error {
 		b, err = v.br.Peek(len(sigPrefix[1:]) + 2)
 		if err != nil {
 			if err == io.EOF {
-				err = errNoSig
+				err = ErrNoSig
 			}
 			return err
 		}
@@ -235,11 +235,11 @@ func (v *volume) findSig() error {
 		if v.num == 0 {
 			v.ver = ver
 		} else if v.ver != ver {
-			return errVerMismatch
+			return ErrVerMismatch
 		}
 		return err
 	}
-	return errNoSig
+	return ErrNoSig
 }
 
 func nextNewVolName(file string) string {
@@ -366,7 +366,7 @@ func (v *volume) openNextFile() error {
 
 func (v *volume) next() error {
 	if len(v.file) == 0 {
-		return errFileNameRequired
+		return ErrFileNameRequired
 	}
 	err := v.Close()
 	if err != nil {


### PR DESCRIPTION
Hi, thank you for the project!
Wondering if there are some interest in exporting error sentinels as public here. 🙏 

I know this was requested at #28 , we also require the sentinel to be public so we can analyze some archives and compare the errors, which otherwise will need to compare the error message directly.

With this change we publish all the sentinels, targeting experimental branch.

I understand if this is not the intended use case, hope we can discuss further on how it's best to analyze rar archive via this package.

Thank you!