### PR TITLE
Added catch for broken files that caused an infinite loop

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -238,6 +238,10 @@ func (f *packedFileReader) bytes() ([]byte, error) {
 			return nil, err
 		}
 		n = len(b)
+		if n == 0 {
+			//File is broken
+			return nil, io.ErrUnexpectedEOF
+		}
 	}
 	b, err := f.v.readSlice(n)
 	f.n -= int64(len(b))


### PR DESCRIPTION
I found an issue where some rar files that were slightly broken would cause the code to go into an infinite loop. My test file was reported as "RAR archive data, v4, os: Win32" from the file command. I verified with other common tools (The Unarchiver and Keka) that the rar file is broken, but some files can be extracted.

This can probably be caught at a different place if needed, this was just the first place I could confirm it broke the loop correctly.

This issue may exist in other reader types too.