### PR TITLE
fix: copyBytes source index wrapping in decode_reader

### DIFF
--- a/decode_reader.go
+++ b/decode_reader.go
@@ -143,6 +143,9 @@ func (d *decodeReader) copyBytes(length, offset int) {
 		d.win[d.w] = d.win[i]
 		d.w++
 		i++
+		if i >= d.size {
+			i = 0
+		}
 		length--
 	}
 }

--- a/decode_reader_test.go
+++ b/decode_reader_test.go
@@ -1,0 +1,15 @@
+package rardecode
+
+import "testing"
+
+func TestCopyBytes_SourceIndexWraps(t *testing.T) {
+	d := &decodeReader{size: 8, win: make([]byte, 8)}
+	d.win[6] = 0xAA
+	d.win[7] = 0xBB
+	d.w = 4
+	// offset=6: source starts at (4-6)%8 = 6, wraps past 7 to 0
+	d.copyBytes(4, 6)
+	if d.win[4] != 0xAA || d.win[5] != 0xBB {
+		t.Errorf("first two bytes wrong: got %x %x, want AA BB", d.win[4], d.win[5])
+	}
+}


### PR DESCRIPTION
Full disclosure, this was found with an LLM analysis.  Seems to be a real issue though - I didn't see a policy on accepting LLM changes or not so creating a pull request.

^^^ human -- LLM vvv

copyBytes is the LZ sliding-window copy primitive used by all RAR decompression versions (v2.0, v2.9, v5.0, v7.0). When the source index reaches the end of the circular window buffer, it must wrap to 0 — this is standard LZ77 circular-buffer behavior, not corruption.

The fast-path bulk-copy branch (i > d.w) already handled this wrap correctly by splitting the copy into two segments. However, the byte-by-byte fallback loop (used when source and destination overlap, e.g. RLE-like patterns) was missing the wrap, causing a panic with index-out-of-range on crafted RAR3 archives.