### PR TITLE
feat: parse RAR5 redirection records (symlinks)

### DIFF
--- a/archive50.go
+++ b/archive50.go
@@ -352,6 +352,37 @@ func (a *archive50) parseFilePrecisionTimeRecord(b *readBuf, f *fileBlockHeader)
 	return nil
 }
 
+// RAR5 file redirection types (extra record type 5).
+// See https://www.rarlab.com/technote.htm
+const (
+	RedirUnixSymlink     = 1
+	RedirWindowsSymlink  = 2
+	RedirWindowsJunction = 3
+	RedirHardLink        = 4
+	RedirFileCopy        = 5
+)
+
+// parseFileRedirectionRecord processes the optional RAR5 file redirection
+// record (symlinks, hard links, and file copies).
+func parseFileRedirectionRecord(b *readBuf, f *fileBlockHeader) error {
+	if len(*b) == 0 {
+		return ErrCorruptFileHeader
+	}
+
+	redirType := int(b.uvarint())
+	_ = b.uvarint() // flags (e.g. directory target); unused for now
+	nlen := int(b.uvarint())
+
+	if nlen < 0 || len(*b) < nlen {
+		return ErrCorruptFileHeader
+	}
+
+	f.RedirType = redirType
+	f.Linkname = string(b.bytes(nlen))
+
+	return nil
+}
+
 func (a *archive50) parseFileHeader(h *blockHeader50) (*fileBlockHeader, error) {
 	f := new(fileBlockHeader)
 
@@ -433,7 +464,7 @@ func (a *archive50) parseFileHeader(h *blockHeader50) (*fileBlockHeader, error) 
 			_ = e.data.uvarint() // ignore flags field
 			f.Version = int(e.data.uvarint())
 		case file5ExtraRedirect:
-			// TODO: redirection
+			err = parseFileRedirectionRecord(&e.data, f)
 		case file5ExtraOwner:
 			// TODO: owner
 		}

--- a/reader.go
+++ b/reader.go
@@ -53,6 +53,12 @@ type FileHeader struct {
 	CreationTime     time.Time // creation time (non-zero if set)
 	AccessTime       time.Time // access time (non-zero if set)
 	Version          int       // file version
+	// Linkname is the target for RAR5 redirections (symlinks, hard links, etc).
+	// Populated from the optional file redirection extra record when present.
+	Linkname string
+	// RedirType is the RAR5 redirection type when Linkname is set.
+	// See https://www.rarlab.com/technote.htm (file redirection record).
+	RedirType int
 }
 
 // Mode returns an fs.FileMode for the file, calculated from the Attributes field.


### PR DESCRIPTION
Hi, human here. I told Cursor (Grok 4.5) to open a PR for my module. Didn't expect it to go upstream. Hope it's useful, and happy to implement changes if requested.

## Summary
- Implements the `TODO: redirection` for RAR5 extra record type 5.
- Adds `FileHeader.Linkname` and `FileHeader.RedirType` so consumers can restore Unix/Windows symlinks (and see hard-link / file-copy redirections).
- Closes #31

Needed by [golift/xtractr#155](https://github.com/golift/xtractr/pull/155) to restore RAR symlinks instead of empty stubs.

## Test plan
- [x] Inspected a `rar a -ol` archive: symlink entry reports `Linkname=target.txt`, `RedirType=1`
- [ ] CI / `go test ./...`


Made with [Cursor](https://cursor.com)