### PR TITLE
Fix panic on out-of-range LZ offset in decodeReader.copyBytes

### DIFF
--- a/copybytes_offset_test.go
+++ b/copybytes_offset_test.go
@@ -1,0 +1,28 @@
+package rardecode
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+// A crafted RAR 5.0 archive whose compressed stream encodes an LZ
+// back-reference offset larger than the decode window. Before the fix
+// this made the source index in copyBytes negative and panicked with a
+// slice bounds out of range. Decoding malformed input must return an
+// error, not panic.
+func TestCopyBytesNegativeOffsetNoPanic(t *testing.T) {
+	archive := []byte{82, 97, 114, 33, 26, 7, 1, 0, 243, 225, 130, 235, 11, 1, 5, 7, 0, 6, 1, 1, 128, 128, 128, 0, 102, 220, 119, 193, 35, 2, 3, 11, 158, 0, 4, 164, 0, 180, 131, 2, 105, 46, 107, 110, 128, 5, 1, 5, 97, 46, 116, 120, 116, 10, 3, 19, 24, 30, 132, 106, 141, 65, 52, 36, 198, 135, 27, 52, 67, 47, 179, 45, 196, 85, 92, 97, 32, 121, 37, 48, 48, 127, 33, 170, 243, 95, 1, 33, 88, 42, 42, 48, 48, 65}
+	r, err := NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return
+	}
+	for {
+		if _, err := r.Next(); err != nil {
+			break
+		}
+		if _, err := io.Copy(io.Discard, r); err != nil {
+			break
+		}
+	}
+}

--- a/decode_reader.go
+++ b/decode_reader.go
@@ -113,7 +113,13 @@ func (d *decodeReader) writeByte(c byte) {
 func (d *decodeReader) copyBytes(length, offset int) {
 	length = (d.size + length) % d.size
 	wend := min(d.w+length, d.size)
-	i := (d.size + d.w - offset) % d.size
+	i := (d.w - offset) % d.size
+	if i < 0 {
+		// offset can exceed d.size+d.w for a corrupt archive,
+		// which makes the modulo negative; wrap it back into
+		// the circular window so we never index out of range.
+		i += d.size
+	}
 	if i == d.w {
 		d.w = wend
 		return


### PR DESCRIPTION
A crafted RAR archive can make the decompressor panic with `slice bounds out of range` instead of returning an error.

**Failure mode**

`copyBytes` computes the circular-window source index as `i := (d.size + d.w - offset) % d.size`. `offset` is the LZ back-reference distance decoded from the stream and can be made larger than `d.size + d.w`. When it is, the dividend is negative and Go's `%` keeps the sign, so `i` is negative and the byte-by-byte fallback copy `d.win[i:d.w]` panics. Any caller decoding untrusted archives is affected (the shared `copyBytes` is used by the v2.0/v2.9/v5.0 decoders).

**Repro**

A 94-byte crafted RAR5 archive fed to `NewReader` + read panics with `slice bounds out of range [-6191:]` at `decode_reader.go:125`. The archive and a regression test are included in `copybytes_offset_test.go`.

**Fix**

Compute the source index with a wrap that is always non-negative, mirroring the `length = (d.size + length) % d.size` normalization on the preceding line. Valid archives always have `offset < d.size`, so their output is unchanged; a corrupt offset now decodes to data that fails the checksum instead of crashing the reader.

**Tests**

Added `TestCopyBytesNegativeOffsetNoPanic`, which panics on the current code and passes with the fix. Verified valid RAR5 archives (stored and compressed) still round-trip to identical bytes.